### PR TITLE
Add admin_only option, and other fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,11 @@
 		"gmail_password": {
 			"description": "Password of gmail account to use for sending emails",
 			"type": "string"
+		},
+		"admin_only": {
+			"description": "If true, only send emails to admin users",
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"command": "python run.py"


### PR DESCRIPTION
This PR adds the admin_only option to the gear, which only sends out emails to admins. It also has a few minor fixes.