### PR TITLE
Fix re-tag 'email' bug

### DIFF
--- a/run.py
+++ b/run.py
@@ -326,10 +326,13 @@ def send_wbhi_email(
         [os.path.join(csv_path, basename) for basename in csv_list],
     )
 
-    if not test_run and not new_matches_df_copy.empty:
+    if site != "admin" and not test_run and not new_matches_df_copy.empty:
         for index, ses_id in new_matches_df_copy["ses_id"].items():
             session = client.get_session(ses_id)
-            session.add_tag("email")
+            if "email" not in session.tags:
+                session.add_tag("email")
+            else:
+                log.error("Session %s already has an 'email' tag.", session.id)
 
 
 def main():


### PR DESCRIPTION
Fixes a bug in which the gear tries to re-tag sessions as 'email', resulting in `flywheel.rest.ApiException: (409) Reason: Tag already exists`. The primary solution is to prevent the 'admin' email function from tagging the sessions.